### PR TITLE
Fix dynamic chat endpoint and starry background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.DS_Store

--- a/Backend/static/css/style.css
+++ b/Backend/static/css/style.css
@@ -1545,8 +1545,8 @@ body::after {
             circle at 80% 70%, rgba(255, 255, 255, 0.1) 0%, 
             transparent 1%
         )
-        radia-gradient(
-            circle at 50% 50%, rgba(255, 255, 255, 0.05) 0%, 
+        radial-gradient(
+            circle at 50% 50%, rgba(255, 255, 255, 0.05) 0%,
             transparent 1%
         );
         background-size: 200% 200%;

--- a/Backend/static/js/chat.js
+++ b/Backend/static/js/chat.js
@@ -668,7 +668,7 @@ class ChatManager {
     async fetchLiveAIResponse(chat, userMessage) {
         try{
             const response = await apiRequest(
-                '/chat/${this.currentChatId}/message',
+                `/chat/${this.currentChatId}/message`,
                 {
                     method : 'POST',
                     body : JSON.stringify({


### PR DESCRIPTION
## Summary
- ignore Python cache files
- fix dynamic URL in chat.js so chat message API endpoint resolves correctly
- correct CSS typo so starry sky background renders

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68807c0f1bc0832aab1798aa2b9c30d7