### PR TITLE
Improve thinking message display

### DIFF
--- a/Backend/static/css/style.css
+++ b/Backend/static/css/style.css
@@ -669,12 +669,15 @@ body::after {
 .sidebar-header::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: radial-gradient(circle at 40% 30%, rgba(255,255,255,0.15), transparent);
+    inset: 0;
     pointer-events: none;
+    background-image:
+        radial-gradient(2px 2px at 20% 30%,rgba(255,255,255,0.8),transparent),
+        radial-gradient(1.5px 1.5px at 80% 70%,rgba(255,255,255,0.6),transparent),
+        radial-gradient(1px 1px at 50% 10%,rgba(255,255,255,0.9),transparent);
+    background-size:100px 100px;
+    animation:star-drift 15s linear infinite;
+    opacity:0.35;
 }
 
 .sidebar-header h2 {
@@ -933,6 +936,23 @@ body::after {
     align-items: center;
     justify-content: space-between;
     flex-shrink: 0;
+    position: relative;
+    overflow: hidden;
+}
+
+.viewer-header::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        radial-gradient(2px 2px at 20% 30%,rgba(255,255,255,0.8),transparent),
+        radial-gradient(1.5px 1.5px at 80% 70%,rgba(255,255,255,0.6),transparent),
+        radial-gradient(1px 1px at 50% 10%,rgba(255,255,255,0.9),transparent);
+    background-size:100px 100px;
+    animation:star-drift 15s linear infinite;
+    opacity:0.35;
+    z-index:0;
 }
 
 .viewer-header h3 {


### PR DESCRIPTION
## Summary
- parse `<think>` sections from AI response
- show streamed AI replies with typing animation
- fix PDF preview by loading document object directly
- animate stars on chat sidebar and viewer header
- convert simple markdown to formatted HTML

## Testing
- `node -c Backend/static/js/chat.js`
- `python3 -m py_compile Backend/app/routes/document.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688495b3bef0832aa83dc01bf10a3471