### PR TITLE
Add logging and streaming to backend

### DIFF
--- a/Backend/app/__init__.py
+++ b/Backend/app/__init__.py
@@ -3,9 +3,10 @@ Flask Application Factory
 Clean architecture with blueprint registration
 """
 
-from flask import Flask, render_template # type: ignore
-from flask_sqlalchemy import SQLAlchemy # type: ignore
-from flask_cors import CORS # type: ignore
+from flask import Flask, render_template  # type: ignore
+from flask_sqlalchemy import SQLAlchemy  # type: ignore
+from flask_cors import CORS  # type: ignore
+import logging
 
 # Initialize extensions
 db = SQLAlchemy()
@@ -20,6 +21,10 @@ def create_app():
     # Load configuration
     from app.config import Config
     app.config.from_object(Config)
+
+    # Configure logging
+    logging.basicConfig(level=logging.DEBUG)
+    app.logger.setLevel(logging.DEBUG)
     
     # Initialize extensions
     db.init_app(app)

--- a/Backend/app/routes/document.py
+++ b/Backend/app/routes/document.py
@@ -2,20 +2,24 @@
 Document API Routes - Complete Implementation
 """
 
-from flask import Blueprint, request, jsonify, current_app # type: ignore
+from flask import Blueprint, request, jsonify, current_app  # type: ignore
 from werkzeug.utils import secure_filename # type: ignore
 from app.services.document_service import DocumentService
 from app.services.auth_service import AuthService
 import os
 import PyPDF2 # type: ignore
+import logging
+from app.models.document import Document
 
 document_bp = Blueprint('document', __name__)
+logger = logging.getLogger(__name__)
 
 @document_bp.route('/list', methods=['GET'])
 def list_documents():
     """Get all documents for current user"""
     try:
         user = AuthService.get_current_user()
+        logger.debug("Listing documents for user %s", user.id)
         documents = DocumentService.get_user_documents(user.id)
         
         return jsonify({
@@ -25,6 +29,7 @@ def list_documents():
         }), 200
         
     except Exception as e:
+        logger.exception("Failed to list documents")
         return jsonify({
             'success': False,
             'message': f'Failed to load documents: {str(e)}'
@@ -35,6 +40,7 @@ def upload_document():
     """Upload PDF document"""
     try:
         user = AuthService.get_current_user()
+        logger.debug("Uploading document for user %s", user.id)
         
         # Check if file is present
         if 'file' not in request.files:
@@ -67,6 +73,7 @@ def upload_document():
             }), 400
             
     except Exception as e:
+        logger.exception("Upload failed")
         return jsonify({
             'success': False,
             'message': f'Upload failed: {str(e)}'
@@ -77,6 +84,7 @@ def get_document(document_id):
     """Get specific document details"""
     try:
         user = AuthService.get_current_user()
+        logger.debug("Fetching document %s for user %s", document_id, user.id)
         document = DocumentService.get_document_status(document_id, user.id)
         
         if document:
@@ -91,6 +99,7 @@ def get_document(document_id):
             }), 404
             
     except Exception as e:
+        logger.exception("Failed to get document %s", document_id)
         return jsonify({
             'success': False,
             'message': f'Failed to get document: {str(e)}'
@@ -101,6 +110,7 @@ def get_document_status(document_id):
     """Get document processing status"""
     try:
         user = AuthService.get_current_user()
+        logger.debug("Checking status for document %s user %s", document_id, user.id)
         document = DocumentService.get_document_status(document_id, user.id)
         
         if document:
@@ -115,6 +125,7 @@ def get_document_status(document_id):
             }), 404
             
     except Exception as e:
+        logger.exception("Failed to get status for document %s", document_id)
         return jsonify({
             'success': False,
             'message': f'Failed to get status: {str(e)}'
@@ -125,6 +136,7 @@ def delete_document(document_id):
     """Delete document"""
     try:
         user = AuthService.get_current_user()
+        logger.debug("Delete request for document %s by user %s", document_id, user.id)
         success, message = DocumentService.delete_document(document_id, user.id)
         
         return jsonify({
@@ -133,6 +145,7 @@ def delete_document(document_id):
         }), 200 if success else 400
         
     except Exception as e:
+        logger.exception("Delete failed for document %s", document_id)
         return jsonify({
             'success': False,
             'message': f'Delete failed: {str(e)}'
@@ -143,6 +156,7 @@ def get_document_content(document_id):
     """Get full document content for preview"""
     try:
         user = AuthService.get_current_user()
+        logger.debug("Preview request for document %s by user %s", document_id, user.id)
         # Fetch the actual Document object so we have access to the stored
         # file_path. DocumentService.get_document_status() omits this field,
         # which caused the previous 404 errors when attempting to preview PDFs.
@@ -155,7 +169,7 @@ def get_document_content(document_id):
             }), 404
 
         file_path = document.file_path
-        
+
         if not file_path or not os.path.exists(file_path):
             return jsonify({
                 'success': False,
@@ -163,6 +177,7 @@ def get_document_content(document_id):
             }), 404
         
         # Extract text from PDF
+        logger.debug("Extracting text for preview from %s", file_path)
         text_content = get_pdf_text_content(file_path)
         
         return jsonify({
@@ -175,6 +190,7 @@ def get_document_content(document_id):
         }), 200
             
     except Exception as e:
+        logger.exception("Failed to get content for document %s", document_id)
         return jsonify({
             'success': False,
             'message': f'Failed to get document content: {str(e)}'
@@ -183,6 +199,7 @@ def get_document_content(document_id):
 def get_pdf_text_content(file_path):
     """Extract text from PDF file"""
     try:
+        logger.debug("Opening PDF for preview: %s", file_path)
         text = ""
         with open(file_path, 'rb') as file:
             pdf_reader = PyPDF2.PdfReader(file)
@@ -194,11 +211,12 @@ def get_pdf_text_content(file_path):
                         text += f"\n--- Page {page_num + 1} ---\n"
                         text += page_text
                 except Exception as e:
-                    print(f"Error extracting page {page_num + 1}: {e}")
+                    logger.error("Preview extraction error page %s: %s", page_num + 1, e)
                     continue
-        
+
+        logger.debug("Preview text length %s", len(text))
         return text.strip()
-            
+
     except Exception as e:
-        print(f"PDF extraction error: {e}")
+        logger.exception("PDF preview extraction failed")
         return "Could not extract text content from PDF"

--- a/Backend/app/services/document_service.py
+++ b/Backend/app/services/document_service.py
@@ -4,7 +4,8 @@ Enhanced with robust error handling and status tracking
 """
 
 import os
-import PyPDF2 # type: ignore
+import logging
+import PyPDF2  # type: ignore
 from datetime import datetime
 from flask import current_app # type: ignore
 from app import db
@@ -13,11 +14,14 @@ from app.models.chat import Chat
 from app.services.rag_service import RAGService
 import threading
 
+logger = logging.getLogger(__name__)
+
 class DocumentService:
     @staticmethod
     def upload_document(file, user_id):
         """Upload and process PDF document"""
         try:
+            logger.debug("Uploading document for user_id=%s", user_id)
             # Validate file
             if not file or not file.filename:
                 return False, "No file provided", None
@@ -41,6 +45,7 @@ class DocumentService:
             file_path = os.path.join(current_app.config['UPLOAD_FOLDER'], filename)
             
             # Save file
+            logger.debug("Saving file to %s", file_path)
             file.save(file_path)
             
             # Create document record
@@ -55,6 +60,7 @@ class DocumentService:
             
             db.session.add(document)
             db.session.commit()
+            logger.debug("Document record created with id=%s", document.id)
             
             # Start async processing
             thread = threading.Thread(
@@ -63,10 +69,12 @@ class DocumentService:
             )
             thread.daemon = True
             thread.start()
+            logger.debug("Background processing started for document %s", document.id)
             
             return True, "Document uploaded successfully", document.to_dict()
-            
+
         except Exception as e:
+            logger.exception("Document upload failed")
             return False, f"Upload failed: {str(e)}", None
     
     @staticmethod
@@ -81,30 +89,36 @@ class DocumentService:
     def _process_document_async(document_id):
         """Process document in background"""
         from app import create_app
-        
+
         app = create_app()
         with app.app_context():
             try:
                 document = Document.query.get(document_id)
                 if not document:
+                    logger.error("Document %s not found for async processing", document_id)
                     return
-                
+
                 # Update status to processing
                 document.update_status('processing', 10)
                 db.session.commit()
+                logger.debug("Document %s status set to processing", document_id)
                 
                 # Extract text from PDF
+                logger.debug("Extracting text from %s", document.file_path)
                 text_content = DocumentService._extract_pdf_text(document.file_path)
                 if not text_content.strip():
                     document.update_status('error', error_message='No readable text found in PDF')
                     db.session.commit()
+                    logger.error("No readable text in document %s", document_id)
                     return
                 
                 document.update_status('processing', 30)
                 db.session.commit()
+                logger.debug("Text extracted for document %s", document_id)
                 
                 # Process with RAG service
                 rag_service = RAGService()
+                logger.debug("Processing document %s with RAG service", document_id)
                 success, message, vector_store_id = rag_service.process_document(
                     text_content=text_content,
                     document_id=document_id,
@@ -116,6 +130,7 @@ class DocumentService:
                     document.vector_store_id = vector_store_id
                     document.chunk_count = len(text_content) // current_app.config['CHUNK_SIZE'] + 1
                     document.update_status('completed', 100)
+                    logger.debug("Document %s processing completed", document_id)
                     
                     # Create default chat session
                     chat = Chat(
@@ -124,11 +139,14 @@ class DocumentService:
                         document_id=document.id
                     )
                     db.session.add(chat)
+                    logger.debug("Default chat created for document %s", document_id)
                     
                 else:
                     document.update_status('error', error_message=message)
+                    logger.error("Processing error for document %s: %s", document_id, message)
                 
                 db.session.commit()
+                logger.debug("Async processing finished for document %s", document_id)
                 
             except Exception as e:
                 try:
@@ -136,14 +154,15 @@ class DocumentService:
                     if document:
                         document.update_status('error', error_message=str(e))
                         db.session.commit()
-                except:
+                except Exception:
                     pass
-                print(f"Document processing error: {e}")
+                logger.exception("Document processing error")
     
     @staticmethod
     def _extract_pdf_text(file_path):
         """Extract text from PDF file"""
         try:
+            logger.debug("Opening PDF file %s", file_path)
             text = ""
             with open(file_path, 'rb') as file:
                 pdf_reader = PyPDF2.PdfReader(file)
@@ -154,18 +173,20 @@ class DocumentService:
                             text += f"\n--- Page {page_num + 1} ---\n"
                             text += page_text
                     except Exception as e:
-                        print(f"Error extracting page {page_num + 1}: {e}")
+                        logger.error("Error extracting page %s: %s", page_num + 1, e)
                         continue
-            
+
+            logger.debug("PDF text extraction complete, %s characters", len(text))
             return text.strip()
-            
+
         except Exception as e:
-            print(f"PDF extraction error: {e}")
+            logger.exception("PDF extraction error")
             return ""
     
     @staticmethod
     def get_user_documents(user_id):
         """Get all documents for a user with status verification"""
+        logger.debug("Fetching documents for user %s", user_id)
         documents = Document.query.filter_by(user_id=user_id)\
                              .order_by(Document.created_at.desc())\
                              .all()
@@ -178,6 +199,7 @@ class DocumentService:
             doc.status = 'processing'
     
         db.session.commit()
+        logger.debug("Retrieved %s documents", len(documents))
     
         return [doc.to_dict() for doc in documents]
 
@@ -185,6 +207,7 @@ class DocumentService:
     @staticmethod
     def get_document_status(document_id, user_id):
         """Get document processing status"""
+        logger.debug("Checking status for document %s", document_id)
         document = Document.query.filter_by(id=document_id, user_id=user_id).first()
         if document:
             return document.to_dict()
@@ -194,8 +217,10 @@ class DocumentService:
     def delete_document(document_id, user_id):
         """Delete document and associated data"""
         try:
+            logger.debug("Deleting document %s for user %s", document_id, user_id)
             document = Document.query.filter_by(id=document_id, user_id=user_id).first()
             if not document:
+                logger.error("Document %s not found", document_id)
                 return False, "Document not found"
             
             # Delete vector store
@@ -209,9 +234,11 @@ class DocumentService:
             # Delete database record (cascades to chats and messages)
             db.session.delete(document)
             db.session.commit()
+            logger.debug("Document %s deleted", document_id)
             
             return True, "Document deleted successfully"
             
         except Exception as e:
             db.session.rollback()
+            logger.exception("Delete failed for document %s", document_id)
             return False, f"Delete failed: {str(e)}"

--- a/Backend/app/services/rag_service.py
+++ b/Backend/app/services/rag_service.py
@@ -7,7 +7,8 @@ import os
 import json
 import shutil
 from datetime import datetime
-from flask import current_app # type: ignore
+from flask import current_app  # type: ignore
+import logging
 from langchain_community.embeddings import OllamaEmbeddings # type: ignore
 from langchain_community.vectorstores import FAISS # type: ignore
 from langchain_community.llms import Ollama # type: ignore
@@ -17,6 +18,8 @@ from langchain.memory import ConversationBufferMemory # type: ignore
 from langchain.schema import Document # type: ignore
 from app import db
 from app.models.chat import Chat
+
+logger = logging.getLogger(__name__)
 
 class RAGService:
     def __init__(self):
@@ -42,8 +45,11 @@ class RAGService:
     def process_document(self, text_content, document_id, filename):
         """Process document for RAG"""
         try:
+            logger.debug("Starting document processing for id=%s", document_id)
+
             # Split text into chunks
             texts = self.text_splitter.split_text(text_content)
+            logger.debug("Split document into %s chunks", len(texts))
             
             if not texts:
                 return False, "No text chunks created from document", None
@@ -64,6 +70,7 @@ class RAGService:
                 documents.append(doc)
             
             # Create vector store
+            logger.debug("Creating vector store")
             vector_store = FAISS.from_documents(documents, self.embeddings)
             
             # Save vector store
@@ -71,20 +78,26 @@ class RAGService:
             store_path = os.path.join(current_app.config['VECTOR_STORE_PATH'], vector_store_id)
             os.makedirs(store_path, exist_ok=True)
             vector_store.save_local(store_path)
+            logger.debug("Vector store saved to %s", store_path)
             
+            logger.debug("Document %s processed successfully", document_id)
             return True, f"Document processed successfully - {len(texts)} chunks created", vector_store_id
-            
+
         except Exception as e:
+            logger.exception("Document processing failed")
             return False, f"Processing failed: {str(e)}", None
     
     def chat_with_document(self, chat_id, user_message):
         """Enhanced chat with conversation memory"""
         try:
+            logger.debug("Chat request for chat_id=%s", chat_id)
             chat = Chat.query.get(chat_id)
             if not chat:
+                logger.error("Chat %s not found", chat_id)
                 return False, "Chat not found", None
-            
+
             if not chat.document.vector_store_id:
+                logger.error("Document not processed for chat %s", chat_id)
                 return False, "Document not processed yet", None
             
             # Load vector store
@@ -93,11 +106,13 @@ class RAGService:
                 chat.document.vector_store_id
             )
             
+            logger.debug("Loading vector store from %s", store_path)
             if not os.path.exists(store_path):
+                logger.error("Vector store not found for chat %s", chat_id)
                 return False, "Document vector store not found", None
             
             vector_store = FAISS.load_local(
-                store_path, 
+                store_path,
                 self.embeddings,
                 allow_dangerous_deserialization=True
             )
@@ -114,10 +129,12 @@ class RAGService:
             context_prompt = self._create_context_prompt(user_message, chat.document.original_filename)
             
             # Perform similarity search
+            logger.debug("Running similarity search")
             relevant_docs = vector_store.similarity_search(
-                user_message, 
+                user_message,
                 k=current_app.config['RETRIEVAL_K']
             )
+            logger.debug("Found %s relevant docs", len(relevant_docs))
             
             # Create context from relevant documents
             context = "\n\n".join([doc.page_content for doc in relevant_docs])
@@ -135,7 +152,9 @@ Instructions: {context_prompt}
 
 Answer:"""
             
+            logger.debug("Sending prompt to LLM")
             response = self.llm(full_prompt)
+            logger.debug("LLM response received, length=%s", len(response))
             
             # Prepare source information
             sources = []
@@ -150,6 +169,7 @@ Answer:"""
             chat.add_message('user', user_message)
             chat.add_message('assistant', response, sources)
             db.session.commit()
+            logger.debug("Messages saved to chat %s", chat_id)
             
             return True, "Response generated", {
                 'response': response,
@@ -159,7 +179,97 @@ Answer:"""
             }
             
         except Exception as e:
+            logger.exception("Chat failed for chat_id=%s", chat_id)
             return False, f"Chat failed: {str(e)}", None
+
+    def chat_with_document_stream(self, chat_id, user_message):
+        """Stream chat response token by token"""
+        logger.debug("Streaming chat for chat_id=%s", chat_id)
+        chat = Chat.query.get(chat_id)
+        if not chat:
+            logger.error("Chat %s not found", chat_id)
+            def gen_error():
+                yield json.dumps({'error': 'Chat not found'})
+            return False, gen_error()
+
+        if not chat.document.vector_store_id:
+            logger.error("Document not processed for chat %s", chat_id)
+            def gen_error():
+                yield json.dumps({'error': 'Document not processed yet'})
+            return False, gen_error()
+
+        store_path = os.path.join(
+            current_app.config['VECTOR_STORE_PATH'],
+            chat.document.vector_store_id
+        )
+        logger.debug("Loading vector store from %s", store_path)
+        if not os.path.exists(store_path):
+            logger.error("Vector store not found for chat %s", chat_id)
+            def gen_error():
+                yield json.dumps({'error': 'Document vector store not found'})
+            return False, gen_error()
+
+        vector_store = FAISS.load_local(
+            store_path,
+            self.embeddings,
+            allow_dangerous_deserialization=True
+        )
+
+        relevant_docs = vector_store.similarity_search(
+            user_message,
+            k=current_app.config['RETRIEVAL_K']
+        )
+        logger.debug("Found %s relevant docs", len(relevant_docs))
+
+        context = "\n\n".join([doc.page_content for doc in relevant_docs])
+        history = []
+        for msg in chat.get_recent_messages(10):
+            if msg.role == 'user':
+                history.append(f"Human: {msg.content}")
+            elif msg.role == 'assistant':
+                history.append(f"AI: {msg.content}")
+
+        context_prompt = self._create_context_prompt(user_message, chat.document.original_filename)
+        full_prompt = f"""Context from document '{chat.document.original_filename}':
+{context}
+
+Conversation History:
+{chr(10).join(history[-6:])}
+
+Current Question: {user_message}
+
+Instructions: {context_prompt}
+
+Answer:"""
+
+        def generator():
+            response_text = ""
+            for chunk in self.llm.stream(full_prompt):
+                logger.debug("LLM token: %s", chunk)
+                response_text += chunk
+                yield chunk
+
+            sources = []
+            for doc in relevant_docs:
+                sources.append({
+                    'chunk_id': doc.metadata.get('chunk_id'),
+                    'chunk_index': doc.metadata.get('chunk_index', 0),
+                    'content': doc.page_content[:200] + "..." if len(doc.page_content) > 200 else doc.page_content
+                })
+
+            chat.add_message('user', user_message)
+            chat.add_message('assistant', response_text, sources)
+            db.session.commit()
+            logger.debug("Streaming chat complete for %s", chat_id)
+
+            yield json.dumps({
+                'response': response_text,
+                'sources': sources,
+                'message_count': chat.message_count,
+                'source_content': sources[0]['content'] if sources else ""
+            })
+
+        return True, generator()
     
     def _create_context_prompt(self, user_message, filename):
         """Create contextual prompt for better responses"""


### PR DESCRIPTION
## Summary
- configure global logging in app factory
- add detailed debug logs to document and chat services
- implement SSE streaming responses in chat routes
- log document preview and processing steps

## Testing
- `python -m py_compile Backend/app/routes/chat.py Backend/app/routes/document.py Backend/app/services/rag_service.py Backend/app/services/document_service.py Backend/app/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68849e8812d4832aa86e5fe1a735f16a