### PR TITLE
Add redis cache and improve highlight handling

### DIFF
--- a/Backend/app/config.py
+++ b/Backend/app/config.py
@@ -24,7 +24,11 @@ class Config:
     # Ollama/AI settings
     OLLAMA_BASE_URL = "http://localhost:11434"
     LLM_MODEL = "granite3.3:2b"
-    EMBEDDING_MODEL = "granite-embedding:278m"
+    EMBEDDING_MODEL = "granite-embedding:8m"
+
+    # Redis cache settings
+    REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
+    REDIS_PORT = int(os.environ.get('REDIS_PORT', 6379))
     
     # RAG settings
     CHUNK_SIZE = 1000

--- a/Backend/config.py
+++ b/Backend/config.py
@@ -28,7 +28,7 @@ class Config:
     # AI Model Configuration
     OLLAMA_BASE_URL = "http://localhost:11434"
     LLM_MODEL = "qwen3:0.6b"  # Your specified model
-    EMBEDDING_MODEL = "granite-embedding:30m"  # Your specified embedding model
+    EMBEDDING_MODEL = "granite-embedding:8m"  # Your specified embedding model
     
     # Vector Store Configuration (FAISS)
     VECTOR_STORE_PATH = "vector_store"

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -16,3 +16,4 @@ numpy
 python-multipart
 Werkzeug
 pydantic
+redis

--- a/Backend/run.py
+++ b/Backend/run.py
@@ -36,7 +36,7 @@ def main():
     print(f"🔌 API Base: http://localhost:5002/api")
     print("=" * 60)
     print("⚠️  Authentication bypassed - Development mode")
-    print("🤖 Models: qwen3:0.6b + granite-embedding:278m")
+    print(f"🤖 Models: qwen3:0.6b + {app.config['EMBEDDING_MODEL']}")
     print("=" * 60)
     
     # Force port 5002 to avoid macOS AirPlay conflicts


### PR DESCRIPTION
## Summary
- switch to lighter 8m embedding model
- add redis configuration and caching in RAG service
- store cached answers for both sync and streaming endpoints
- auto-scroll to highlighted source page in preview
- update run message and requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884e8884d70832a973c78b0e453dde9