### PR TITLE
Fix schema migration for SQLAlchemy 2

### DIFF
--- a/Backend/run.py
+++ b/Backend/run.py
@@ -4,8 +4,25 @@ Clean architecture with no authentication
 """
 
 import os
+from sqlalchemy import text
 from app import create_app, db
 from app.models.user import User
+from app.models.document import Document
+from app.models.chat import Chat, ChatMessage
+
+
+def _ensure_columns(table_name, columns):
+    """Add missing columns to an existing table using SQLite PRAGMA."""
+    try:
+        with db.engine.connect() as conn:
+            result = conn.execute(text(f"PRAGMA table_info({table_name})"))
+            existing_cols = {row['name'] for row in result.mappings()}
+        for col, coltype in columns.items():
+            if col not in existing_cols:
+                with db.engine.connect() as conn:
+                    conn.execute(text(f"ALTER TABLE {table_name} ADD COLUMN {col} {coltype}"))
+    except Exception as exc:
+        print(f"⚠️  Schema update warning for {table_name}: {exc}")
 
 def create_tables(app):
     """Create or update database tables and insert a default user if needed."""
@@ -13,36 +30,62 @@ def create_tables(app):
         # Create all tables if they do not exist
         db.create_all()
 
-        # Ensure the users table has all expected columns.  SQLite does not
-        # support ALTER TABLE for multiple columns at once, so we add any
-        # missing columns individually.  This is a simple schema-migration
-        # helper to avoid OperationalError when models change in development.
-        try:
-            # Introspect existing columns using SQLite PRAGMA
-            result = db.engine.execute("PRAGMA table_info(users)")
-            existing_cols = {row['name'] for row in result}
-            # Define the expected columns and their SQL types.  Use types
-            # compatible with SQLite.  If you add more columns to the User
-            # model, update this dictionary accordingly.
-            expected_cols = {
-                'first_name': 'VARCHAR(50)',
-                'last_name': 'VARCHAR(50)',
-                'profile_picture': 'VARCHAR(255)',
-                'is_active': 'BOOLEAN',
-                'is_verified': 'BOOLEAN',
-                'is_admin': 'BOOLEAN',
-                'created_at': 'DATETIME',
-                'updated_at': 'DATETIME',
-                'last_login': 'DATETIME'
-            }
-            for col, coltype in expected_cols.items():
-                if col not in existing_cols:
-                    db.engine.execute(f"ALTER TABLE users ADD COLUMN {col} {coltype}")
-        except Exception as schema_exc:
-            # Log a warning but continue.  In cases where the schema
-            # modification fails (e.g. due to unsupported ALTER), the developer
-            # may need to manually migrate or drop the DB.
-            print(f"⚠️  Schema update warning: {schema_exc}")
+        # Ensure all tables contain expected columns for backward compatibility
+        user_cols = {
+            'first_name': 'VARCHAR(50)',
+            'last_name': 'VARCHAR(50)',
+            'profile_picture': 'VARCHAR(255)',
+            'is_active': 'BOOLEAN',
+            'is_verified': 'BOOLEAN',
+            'is_admin': 'BOOLEAN',
+            'created_at': 'DATETIME',
+            'updated_at': 'DATETIME',
+            'last_login': 'DATETIME'
+        }
+        document_cols = {
+            'original_filename': 'VARCHAR(255)',
+            'file_path': 'VARCHAR(500)',
+            'file_size': 'FLOAT',
+            'status': 'VARCHAR(50)',
+            'processing_progress': 'INTEGER',
+            'error_message': 'TEXT',
+            'vector_store_id': 'VARCHAR(100)',
+            'chunk_count': 'INTEGER',
+            'created_at': 'DATETIME',
+            'updated_at': 'DATETIME',
+            'processed_at': 'DATETIME',
+            'user_id': 'INTEGER'
+        }
+        chat_cols = {
+            'memory_type': 'VARCHAR(50)',
+            'max_tokens': 'INTEGER',
+            'temperature': 'FLOAT',
+            'system_prompt': 'TEXT',
+            'status': 'VARCHAR(50)',
+            'message_count': 'INTEGER',
+            'total_tokens_used': 'INTEGER',
+            'created_at': 'DATETIME',
+            'updated_at': 'DATETIME',
+            'last_activity': 'DATETIME',
+            'user_id': 'INTEGER',
+            'document_id': 'INTEGER'
+        }
+        chat_message_cols = {
+            'role': 'VARCHAR(20)',
+            'content': 'TEXT',
+            'sources': 'TEXT',
+            'token_count': 'INTEGER',
+            'model_used': 'VARCHAR(100)',
+            'processing_time': 'FLOAT',
+            'confidence_score': 'FLOAT',
+            'created_at': 'DATETIME',
+            'chat_id': 'INTEGER'
+        }
+
+        _ensure_columns('users', user_cols)
+        _ensure_columns('documents', document_cols)
+        _ensure_columns('chats', chat_cols)
+        _ensure_columns('chat_messages', chat_message_cols)
 
         # Create default user for bypass authentication
         default_user = User.query.filter_by(username='default').first()


### PR DESCRIPTION
## Summary
- update schema migration logic to use `text` and `engine.connect`
- add SQLAlchemy import

## Testing
- `pytest -q`
- `python -m py_compile Backend/run.py`


------
https://chatgpt.com/codex/tasks/task_e_688b80e7059c832aa51510eb2073067e