### PR TITLE
feat: add optional table visualization, cache fallback, and qwen model

### DIFF
--- a/Backend/app/config.py
+++ b/Backend/app/config.py
@@ -27,8 +27,8 @@ class Config:
     
     # AI Model Configuration
     OLLAMA_BASE_URL = "http://localhost:11434"
-    LLM_MODEL = "granite3.3:2b"  # Your specified model
-    EMBEDDING_MODEL = "granite-embedding:30m"  # Your specified embedding model
+    LLM_MODEL = "qwen3:0.6b"  # Lightweight Qwen model
+    EMBEDDING_MODEL = "all-minilm:33m"  # Small embedding model
     
     # Vector Store Configuration (FAISS)
     VECTOR_STORE_PATH = "vector_store"
@@ -36,7 +36,7 @@ class Config:
     # Retrieval configuration
     # Number of relevant document chunks to retrieve from the vector store for each query.  
     # A lower value reduces latency but may miss some context; adjust based on your needs.
-    RETRIEVAL_K = int(os.environ.get('RETRIEVAL_K', 4))
+    RETRIEVAL_K = int(os.environ.get('RETRIEVAL_K', 3))
 
     # Redis configuration for caching
     REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
@@ -45,8 +45,8 @@ class Config:
     # Chat Configuration
     CHAT_STORAGE_PATH = "chats"
     MAX_CHAT_HISTORY = 50
-    CHUNK_SIZE = 1000
-    CHUNK_OVERLAP = 200
+    CHUNK_SIZE = 800
+    CHUNK_OVERLAP = 120
     
     # Memory Configuration
     MEMORY_TYPE = "buffer"  # Options: buffer, summary, hybrid

--- a/Backend/app/routes/chat.py
+++ b/Backend/app/routes/chat.py
@@ -175,10 +175,11 @@ def send_message(chat_id):
         # For now, use the primary document for processing
         # In a full implementation, you'd enhance RAGService for multi-document support
         stream = data.get('stream', False)
+        visualize = data.get('visualize', False)
         rag_service = RAGService()
 
         if stream:
-            success, generator = rag_service.chat_with_document_stream(chat_id, user_message)
+            success, generator = rag_service.chat_with_document_stream(chat_id, user_message, visualize=visualize)
             if not success:
                 first = next(generator)
                 return Response(f"data: {first}\n\n", mimetype='text/event-stream')
@@ -190,7 +191,7 @@ def send_message(chat_id):
             logger.debug("Streaming response for chat %s", chat_id)
             return Response(stream_with_context(event_stream()), mimetype='text/event-stream')
         else:
-            success, message, response_data = rag_service.chat_with_document(chat_id, user_message)
+            success, message, response_data = rag_service.chat_with_document(chat_id, user_message, visualize=visualize)
             if success:
                 logger.debug("Returning full response for chat %s", chat_id)
                 return jsonify({

--- a/Backend/config.py
+++ b/Backend/config.py
@@ -27,8 +27,8 @@ class Config:
     
     # AI Model Configuration
     OLLAMA_BASE_URL = "http://localhost:11434"
-    LLM_MODEL = "granite3.3:2b"  # Your specified model
-    EMBEDDING_MODEL = "granite-embedding:30m"  # Your specified embedding model
+    LLM_MODEL = "qwen3:0.6b"  # Lightweight Qwen model
+    EMBEDDING_MODEL = "all-minilm:33m"  # Small embedding model
     
     # Vector Store Configuration (FAISS)
     VECTOR_STORE_PATH = "vector_store"

--- a/Backend/logic.py
+++ b/Backend/logic.py
@@ -22,8 +22,8 @@ CHATS_DIR = "./chats"
 #defines a directory to store chat history
 os.makedirs(CHATS_DIR, exist_ok=True)
 
-LLM_MODEL = "deepseek-r1:1.5b"
-EMBED_MODEL = "granite-embedding:278m"
+LLM_MODEL = "qwen3:0.6b"
+EMBED_MODEL = "all-minilm:33m"
 
 llm = OllamaLLM(model=LLM_MODEL, temperature=0.5)
 embeddings = OllamaEmbeddings(model=EMBED_MODEL)

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -5,6 +5,7 @@ Flask-CORS
 Flask-Migrate
 langchain
 langchain-community
+langchain-ollama
 PyPDF2
 python-dotenv
 bcrypt
@@ -20,3 +21,6 @@ redis
 matplotlib
 scikit-learn
 scipy
+pandas
+pdfplumber
+squarify

--- a/Backend/run.py
+++ b/Backend/run.py
@@ -142,7 +142,7 @@ def main():
     print(f"🔌 API Base: http://localhost:5002/api")
     print("=" * 60)
     print("⚠️  Authentication bypassed - Development mode")
-    print(f"🤖 Models: qwen3:0.6b + {app.config['EMBEDDING_MODEL']}")
+    print(f"🤖 Models: {app.config['LLM_MODEL']} + {app.config['EMBEDDING_MODEL']}")
     print("=" * 60)
     
     # Force port 5002 to avoid macOS AirPlay conflicts


### PR DESCRIPTION
## Summary
- add in-memory TTL cache when Redis is unavailable
- support optional table visualizations triggered by a `visualize` flag
- shrink retrieval parameters for faster responses
- default to lightweight Qwen3 model with MiniLM embeddings and `langchain-ollama`

## Testing
- `python -m py_compile Backend/app/services/rag_service.py Backend/app/routes/chat.py Backend/app/config.py Backend/config.py Backend/logic.py Backend/run.py Backend/requirements.txt`
- `python - <<'PY'
import langchain_ollama, pdfplumber, pandas, squarify
print('imports ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689e0be695ec832abcd6fcac2d3cfff7